### PR TITLE
fix mutation / copying / cloning bugs

### DIFF
--- a/Automata.py
+++ b/Automata.py
@@ -57,7 +57,7 @@ class Automaton:
         reset payoff and current state to initial strategy
         :return: Automaton
         """
-        return Automaton(self.current, 0, self.table, self.initial)
+        return Automaton(self.initial, 0, self.table, self.initial)
 
     #TODO: cannot type due to bug
     def reset(self):

--- a/Population.py
+++ b/Population.py
@@ -17,7 +17,6 @@ class Population:
     #TODO: cannot add a return type due to bug
     def __init__(self, a: List(Automaton)):
         self.a = a
-        self.b = [copy(x) for x in a]
 
     def payoffs(self):
         result = []
@@ -52,26 +51,22 @@ class Population:
         """
         payoffs = self.payoffs()
         substitutes = choose_randomly(payoffs, rate)
-        # clone all automata in a at substitues
-        # then "move" these clones into the first "rate" slots of a
         for i in range(rate):
             index = substitutes[i]
-            self.a[i] = copy(self.b[index])
+            self.a[i] = self.a[index].clone()
         self.shuffle()
         return self
 
     #TODO: add types to void
     def shuffle(self):
-        self.b = [copy(x) for x in self.a]
+        b = copy(self.a)
         for i in range(len(self.a)):
             #j = randrange(i + 1)
             j = next(rand_num)
             if j != i:
-                self.b[i] = self.b[j]
-            self.b[j] = self.a[i]
-        tmp = [copy(x) for x in self.a]
-        self.a = [copy(x) for x in self.b]
-        self.b = tmp
+                b[i] = b[j]
+            b[j] = self.a[i]
+        self.a = b
 
     #TODO: program crashes when adding a void return type
     def reset(self):
@@ -79,5 +74,4 @@ class Population:
         Reset all automata in a
         :return: None
         """
-        for element in self.a:
-            element.reset()
+        self.a = [element.reset() for element in self.a]


### PR DESCRIPTION
Found a couple bugs. These were nasty. Now I get "approximately right" results.

```
> racket fsm0.rkt
cpu time: 5 real time: 6 gc time: 0
'((0 2.064) (1 2.128) (2 2.121) (3 2.042) (4 2.056) (5 2.13) (6 2.1) (7 1.981) (8 2.076) (9 1.946))
> python Fsm0.py
[[0, 2.064], [1, 2.166], [2, 2.149], [3, 2.09], [4, 2.135], [5, 2.138], [6, 2.123], [7, 2.073], [8, 2.081], [9, 2.141]]
```

So there might be more bugs. If you find any that's great, otherwise I'd say we're ready to see how adding / removing types affects performance.

The bugs:
- `regenerate` needs to `clone` automata, and `clone` needs to set the current state to `initial`.
- `reset` needs to update `self.a`
- `self.b` (or `b*`) needs to SHARE with `a*`. (You were right to only use `b` when shuffling. Sorry!)